### PR TITLE
Fix typos across documentation

### DIFF
--- a/ARRAY_AND_STRING/overview.md
+++ b/ARRAY_AND_STRING/overview.md
@@ -8,7 +8,7 @@ In this card we will introduce array and string. After finishing this card you s
 5. Be able to apply the `two-pointer technique` to practical problems.
 
 ## intro to array
-- intro to aray
+- intro to array
 - intro to dynamic array
 - find pivot index
 - largest number at least twice of others
@@ -21,7 +21,7 @@ In this card we will introduce array and string. After finishing this card you s
 - pascal's triangle
 
 ## intro to String
-- inntro to String
+- intro to String
 - immutable string - problems & solutions
 - add binary
 - implement strStr()
@@ -30,7 +30,7 @@ In this card we will introduce array and string. After finishing this card you s
 ## two pointer technique
 - reverse string
 - array partition i
-- two sum ii - input arrray is sorted!!!!!!!!!
+- two sum ii - input array is sorted!!!!!!!!!
 - two pointer technique - scenario ii
 - remove element
 - max consecutive ones

--- a/BINARY_SEARCH/intro.md
+++ b/BINARY_SEARCH/intro.md
@@ -2,13 +2,13 @@
 In this card we are going to help you understand the general concept of Binary Search
 
 ## What is Binary Search?
-Binary Search is one of the most fundamental and useful algorithms in Computer Science. It describes the process of searching for a specific value in an ordered collectioin
+Binary Search is one of the most fundamental and useful algorithms in Computer Science. It describes the process of searching for a specific value in an ordered collection
 
 Terminology used in Binary Search
 - target - the value that you're searching for
 - index - the current location that you're searching
 - left, right - the indices which we use to maintain our search space
-- miid - the index thata we use to apply a condition to determine if we should search left or right
+- mid - the index that we use to apply a condition to determine if we should search left or right
 
 Other Binary Search definitions
 Wikipedia

--- a/BINARY_SEARCH_TREE/intro.md
+++ b/BINARY_SEARCH_TREE/intro.md
@@ -1,5 +1,5 @@
 # Introduction
-A `Binary Search Tree` is a special form of binary tree. The value in each node must be `grerater than` (or equal to) any values in its `left subtree` but `less than` (or equal to) any values in its `right subtree`
+A `Binary Search Tree` is a special form of binary tree. The value in each node must be `greater than` (or equal to) any values in its `left subtree` but `less than` (or equal to) any values in its `right subtree`
 
 We'll go through this definition more specifically in this chapter and provide you some exercises related to the binary search tree
 
@@ -7,3 +7,4 @@ The goal of this card is to
 1. understand the `properties` of a binary tree
 2. be able to do `basic operations` in a binary search tree
 3. understand the concept of a `height-balanced binary search tree`
+

--- a/DECISION_TREE/overview.md
+++ b/DECISION_TREE/overview.md
@@ -6,11 +6,11 @@ this card is intended to illustrate a classic algorithm for the classification p
 by completing this card u will b able to
 1. understand the intuition behind decision tree
 2. implement the algo of `decision tree`
-3. understand the important metrics (`gini impurity`, `entropy`) that contructing a decisiion tree involves
+3. understand the important metrics (`gini impurity`, `entropy`) that constructing a decision tree involves
 4. know how to evaluate the performance of decision tree model and the importance of input features
 
 ## definition
-- defintion - decision tree
+- definition - decision tree
 - model inference - decision tree
 - algo - decision tree
 
@@ -25,3 +25,4 @@ by completing this card u will b able to
 ## evaluation
 - precision vs recall
 - feature importance - decision tree
+

--- a/GRAPH/intro.md
+++ b/GRAPH/intro.md
@@ -1,4 +1,5 @@
 # Introduction
-The content on this card iis exlcusive to our premium users. If you like the content after previewing the first chapter for free please subscribe to LeetCode premium here
+The content on this card is exclusive to our premium users. If you like the content after previewing the first chapter for free please subscribe to LeetCode premium here
 
 `Graph` is probably the data structure that has the closest resemblance to our daily life. There are many types of graphs describing the relationships in real life. For instance our friend circle is a huge "graph"
+

--- a/HASH_TABLE/Overview.md
+++ b/HASH_TABLE/Overview.md
@@ -2,7 +2,7 @@
 `Hash Table` is a data structure which organizes data using `hash functions` in order to support quick insertion and search.
 There are two different kinds of hash tables: hash set and hash map.
 - The `hash set` is one of the implementations of a `set` data structure to store `no repeated values`.
-- The `hash map` is one of the implemnentations of a `map` data structure to store `(key, value)` pairs.
+- The `hash map` is one of the implementations of a `map` data structure to store `(key, value)` pairs.
 It is `easy to use` a hash table with the help of `standard template libraries`. Most common languages such as Java, C++ and Python support both hash set and hash map.
 By choosing a proper hash function the hash table can achieve `wonderful performance` in both insertion and search.
 In this card we will answer the following questions:

--- a/HEAP/intro.md
+++ b/HEAP/intro.md
@@ -1,11 +1,11 @@
 # Introduction
 The content on this card is exclusive to our premium users. If you like the content after previewing the first chapter for free, please subscribe to LeetCode premium here
 
-In many computer science applications we only need to access the **largest** or **smallest** element in the dataset. We do not care about the order of other data in the data set. How do we efficiently access the largest or smallest element in the current dataseet? The answer would be **Heap**
+In many computer science applications we only need to access the **largest** or **smallest** element in the dataset. We do not care about the order of other data in the data set. How do we efficiently access the largest or smallest element in the current dataset? The answer would be **Heap**
 
 In this explore card we will introduce **Heap**. After reading this section you will
 - have a better understanding of the "Heap" data structure and its implementation
 - have a better understanding of the concepts and methods of **Max Heap** and **Min Heap**
 - have a better understanding of **Heap Sort**
 - have a better understanding of the application scenarios of "Heap"
-- be able to use "Heap" in practice 
+- be able to use "Heap" in practice

--- a/MACHINE_LEARNING_101/overview.md
+++ b/MACHINE_LEARNING_101/overview.md
@@ -2,10 +2,10 @@
 in this explore card we introduce some basic concepts in the domain of machine learning
 
 by completing this card u will b able to
-1. identify diff types of machine learniing problems
-2. know what a machine learniing model is
+1. identify diff types of machine learning problems
+2. know what a machine learning model is
 3. know the general workflow of building and applying a machine learning model
-4. know the advantages and disadvantages about machine leaarning algorithms
+4. know the advantages and disadvantages about machine learning algorithms
 
 ## machine learning - what
 - machine learning model

--- a/N-ARY_TREE/intro.md
+++ b/N-ARY_TREE/intro.md
@@ -1,7 +1,7 @@
 # Introduction
-In the previous article we focused morre on binary tree. This card extends the concept you have learned in binary tree to n-ary tree
+In the previous article we focused more on binary tree. This card extends the concept you have learned in binary tree to n-ary tree
 
 By completing this card you will
 1. understand the definition of an n-ary tree
 2. know the different traversal of n-ary trees
-3. have basic knowledge of how to approach n-ary tree problems 
+3. have basic knowledge of how to approach n-ary tree problems

--- a/QUEUE_&_STACK/intro.md
+++ b/QUEUE_&_STACK/intro.md
@@ -3,7 +3,7 @@ We may access a `random` element by index in Array. However we might want to `re
 
 In this card we introduce two different processing orders `first-in-first-out` and `last-in-last-out` and its two corresponding linear data structures `Queue` and `Stack`
 
-We go through the definition implementation and built-in functions for each data structure. Then we focus more on the praactical applications of these two data structures
+We go through the definition implementation and built-in functions for each data structure. Then we focus more on the practical applications of these two data structures
 
 By completing this card you should be able to 
 1. understand the principle of processing orders of FIFO and LIFO

--- a/SORTING/overview.md
+++ b/SORTING/overview.md
@@ -1,7 +1,7 @@
 # intro
-the target audience for this card is anyone who wants to learn sorting from the group up or anyone that wants to refresh the core concepts involved in sorting algos. all levels are welcome but most of this card assumes minimal knowledge of sorting algos
+the target audience for this card is anyone who wants to learn sorting from the ground up or anyone that wants to refresh the core concepts involved in sorting algos. all levels are welcome but most of this card assumes minimal knowledge of sorting algos
 
-in this card we will develop a framework for understanndinng and evaluating various sorting algos. the focus will be on knowinng the tradeoffs of the various algos along with the overarching themes and implementation details
+in this card we will develop a framework for understanding and evaluating various sorting algos. the focus will be on knowing the tradeoffs of the various algos along with the overarching themes and implementation details
 
 by the end of this card u should have a solid understanding of a variety of sorting algos and feel comfortable applying the concepts of these algos to various problems
 

--- a/SYSTEM_DESIGN/overview.md
+++ b/SYSTEM_DESIGN/overview.md
@@ -1,9 +1,9 @@
 # intro
-understanding and mastering system design qs r crucial in practicing for software engineering interviews. if ur not properly prepared for these qs n concepts in ur interview ull miss out on the opportunities of expanding ur career with a better paying position or even with a great company
+understanding and mastering system design questions are crucial in practicing for software engineering interviews. if you're not properly prepared for these questions and concepts in your interview you'll miss out on the opportunities of expanding your career with a better paying position or even with a great company
 
-now u wont have to sweat ur next interview. written by an expert FAANG tech lead with experience giving and taking over 500 system design interviews u can easily use this course to level up ur system design knowledge and nail future interviews
+now you won't have to sweat your next interview. written by an expert FAANG tech lead with experience giving and taking over 500 system design interviews you can easily use this course to level up your system design knowledge and nail future interviews
 
-u wont b able to find a system design course quite like this one. not only will u experience FAANG level case studies but ull have the direct ability to practice real world interview problems created by FAANG interviewers and apply the skills uve learned here!!!!
+you won't be able to find a system design course quite like this one. not only will you experience FAANG level case studies but you'll have the direct ability to practice real world interview problems created by FAANG interviewers and apply the skills you've learned here!!!!
 
 ## intro to system design
 - intro to system design
@@ -19,7 +19,7 @@ u wont b able to find a system design course quite like this one. not only will 
 - databases
 - rate limiting
 - design log aggregation system
-- design consistent hashing algo
+- design consistent hashing algorithm
 - design a rate limiting system
 - design a load distributor slash balancer (LB)
 - design an application monitoring system
@@ -30,7 +30,7 @@ u wont b able to find a system design course quite like this one. not only will 
 - google maps system design
 - airbnb system design
 - netflix system design
-- notfication service system design
+- notification service system design
 - tinyurl system design
 - twitter system design
 - uber system design
@@ -46,3 +46,4 @@ u wont b able to find a system design course quite like this one. not only will 
 - ticket booking app
 - food delivery app
 - practice problems
+

--- a/TRIE/overview.md
+++ b/TRIE/overview.md
@@ -1,7 +1,7 @@
 # Introduction
 `Trie` aka `prefix tree` is a special form of a `Nary tree`
 
-In this card we will go deep into the implementatioin of Trie and talk about how to use this data structure to solve problems
+In this card we will go deep into the implementation of Trie and talk about how to use this data structure to solve problems
 
 After completing this card you should be able to 
 1. understand the `concept` of Trie


### PR DESCRIPTION
## Summary
- Corrected spelling mistakes and list labels across the array, trie, hash table, heap, graph, queue/stack, and n-ary tree explore cards.
- Fixed typographical errors in algorithm-oriented intros, including binary search, binary search tree, sorting, and decision tree documentation.
- Clarified wording and corrected typos in system design and machine learning overview pages.

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c9f40bc28c8333ab2461f5dfc17a44